### PR TITLE
Make configure change the defaults rather than overwriting the options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ export function configure(_proxyUrl: string, _strictSSL: boolean): void {
 export function xhr(options: XHROptions): Promise<XHRResponse> {
 	const agent = getProxyAgent(options.url, { proxyUrl, strictSSL });
 	options = assign({}, options);
-	options = assign(options, { agent, strictSSL });
+	options = assign({ agent, strictSSL }, options);
 	if (typeof options.followRedirects !== 'number') {
 		options.followRedirects = 5;
 	}


### PR DESCRIPTION
Currently calling the configure function would overwrite every xhr request with those values, rather than just being the default (I assume was the point).

Changing the ordering of the assign so that the global values configured by configure just set the defaults, but the options passed in during the request are used if passed.