### PR TITLE
fix request should failed when invaild proxy provided

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -12,6 +12,7 @@ export interface XHROptions {
     data?: string;
     strictSSL?: boolean;
     followRedirects?: number;
+    agent?: HttpProxyAgent | HttpsProxyAgent;
 }
 
 export interface XHRResponse {
@@ -28,6 +29,10 @@ export interface XHRRequest {
 export interface XHRConfigure {
     (proxyUrl: string, strictSSL: boolean): void;
 }
+
+export type HttpProxyAgent = import('http-proxy-agent').HttpProxyAgent;
+
+export type HttpsProxyAgent = import('https-proxy-agent').HttpsProxyAgent;
 
 export type Headers = { [header: string]: string | string[] | undefined };
 

--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -137,6 +137,7 @@ function request(options: XHROptions): Promise<RequestResult> {
 
 		let opts: https.RequestOptions = {
 			hostname: endpoint.hostname,
+			agent: options.agent ? options.agent : false,
 			port: endpoint.port ? parseInt(endpoint.port) : (endpoint.protocol === 'https:' ? 443 : 80),
 			path: endpoint.path,
 			method: options.type || 'GET',
@@ -248,7 +249,8 @@ function getProxyAgent(rawRequestURL: string, options: ProxyOptions = {}): any {
 		host: proxyEndpoint.hostname,
 		port: Number(proxyEndpoint.port),
 		auth: proxyEndpoint.auth,
-		rejectUnauthorized: (typeof options.strictSSL === 'boolean') ? options.strictSSL : true
+		rejectUnauthorized: (typeof options.strictSSL === 'boolean') ? options.strictSSL : true,
+		protocol: proxyEndpoint.protocol
 	};
 
 	return requestURL.protocol === 'http:' ? createHttpProxyAgent(opts) : createHttpsProxyAgent(opts);


### PR DESCRIPTION
The PR fix supports the http request should throw error when invalid proxy configured.

This problem found by users of yaml-language-server, issue: https://github.com/redhat-developer/yaml-language-server/issues/588