### PR TITLE
Add package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
     "./lib/node/main.js": "./lib/browser/main.js"
   },
   "typings": "./api",
+  "exports": {
+    ".": {
+      "types": "./api.d.ts",
+      "browser": "./lib/browser/main.js",
+      "default": "./lib/node/main.js"
+    }
+  },
   "author": "Microsoft Corporation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This ensures the browser API is used for the `browser` condition, and the Node.js API for everything else.

The top-level `main` and `browser` fields are redundant, but I decided to not remove them yet.